### PR TITLE
Updated draco. It was Cygnus 2.0.0 test

### DIFF
--- a/json/draco.json
+++ b/json/draco.json
@@ -3,7 +3,7 @@
 	"docCompleteness": "A",
 	"docSoundness" : "A+",
 	"failureRate" : "A+++",
-	"failureValue" : 0.08,
+	"failureValue" : 0,
 	"scalability" : "A+++",
 	"scalabilityValue" : 1.02,
 	"performance" : "A+++",


### PR DESCRIPTION
I updated the Draco test. In the QA Test plan it was named Cygnus 2.0.0. I'he noticed for Draco, IoT Agent OPC-UA and APinf there aren't "Quality Assurance" sections in the [catalogue](https://github.com/FIWARE/catalogue) although the JSON files are available. 